### PR TITLE
fix: Allow non-email username for dev bypass in login form

### DIFF
--- a/login.html
+++ b/login.html
@@ -14,8 +14,8 @@
         <h2>Login</h2>
         <form id="login-form">
             <div>
-                <label for="email">Email:</label>
-                <input type="email" id="email" name="email" required>
+                <label for="email">Email/Username:</label> <!-- Changed label slightly for clarity with bypass -->
+                <input type="text" id="email" name="email" required> <!-- DEV_BYPASS_CHANGE: type="email" to type="text" to allow 'a' as username. Review when bypass removed. -->
             </div>
             <div>
                 <label for="password">Password:</label>


### PR DESCRIPTION
Changed the input type for the email/username field in `login.html` from `type="email"` to `type="text"`.

This change disables the browser's default email format validation, allowing the username "a" to be used for the development login bypass (which uses username "a" and password "b" when Supabase is not yet configured).

An HTML comment has been added to flag this as a temporary change that should be reviewed or reverted when the development bypass logic is removed from `js/auth.js`.